### PR TITLE
Use top_srcdir for path to opts.ggo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,8 +52,8 @@ mmv.1: mmv.c build-aux/mmv-help2man-wrapper mmv-include.man
 
 mmv.o: cmdline.h
 
-cmdline.h cmdline.c: opts.ggo
-	gengetopt < opts.ggo --unamed-opts
+cmdline.h cmdline.c: $(top_srcdir)/opts.ggo
+	gengetopt < $(top_srcdir)/opts.ggo --unamed-opts
 
 all-local: mmv$(EXEEXT)
 	$(MAKELINKS)


### PR DESCRIPTION
This fixes out-of-tree builds, which otherwise will fail when attempting to run `gengetopt`:

````console
$ mkdir build; cd build
$ ../configure
$ make
[...]
make[2]: Entering directory '.../mmv/build'
gengetopt < opts.ggo --unamed-opts
/bin/sh: line 1: opts.ggo: No such file or directory
make[2]: *** [Makefile:2205: cmdline.h] Error 1
make[2]: Leaving directory '.../mmv/build'
make[1]: *** [Makefile:1755: all-recursive] Error 1
make[1]: Leaving directory '.../mmv/build'
make: *** [Makefile:1556: all] Error 2
```
