### PR TITLE
Update opts.ggo: add 'c' for capitalization

### DIFF
--- a/opts.ggo
+++ b/opts.ggo
@@ -5,8 +5,8 @@ usage " [-m|-x|-r|-c|-o|-a|-l|-s] [-h] [-d|-p] [-g|-t] [-v|-n] FROM TO"
 description "The FROM pattern is a shell glob pattern, in which `*' stands for any number
 of characters and `?' stands for a single character.
 
-Use #[l|u]N in the TO pattern to get the string matched by the Nth
-FROM pattern wildcard [lowercased|uppercased].
+Use #[l|u|c]N in the TO pattern to get the string matched by the Nth
+FROM pattern wildcard [lowercased|uppercased|capitalize].
 
 Patterns should be quoted on the command line."
 


### PR DESCRIPTION
add 'c' for capitalization: make the first letter of the word(s) as a capital, for example：
here two files: mmv.c and opts.ggo, or mmV.C and OpTs.GGO, when we run `mmv '*' '#c1'`, the name of these two files will be Mmv.c and Opts.ggo.